### PR TITLE
feat(index): add additional password hashing algorithms to userSchema to match BAPI spec

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,11 +43,17 @@ const userSchema = z.object({
 			"argon2i",
 			"argon2id",
 			"bcrypt",
+			"bcrypt_sha256_django",
+			"ldap_ssha",
 			"md5",
+			"md5_phpass",
 			"pbkdf2_sha256",
 			"pbkdf2_sha256_django",
 			"pbkdf2_sha1",
+			"phpass",
 			"scrypt_firebase",
+			"scrypt_werkzeug",
+			"sha256",
 		])
 		.optional(),
 	/** Metadata saved on the user, that is visible to both your Frontend and Backend APIs */


### PR DESCRIPTION
[SUP-805](https://linear.app/clerk/issue/SUP-805/update-the-list-of-supported-passwordhasher-values-to-match-current)

- This PR adds `bcrypt_sha256_django`, `ldap_ssha`, `md5_phpass`, `phpass`, `scrypt_werkzeug`, and `sha256` to the `userSchema` Zod validation schema, in order to match our BAPI spec and enable usage of all supported password hashers