### PR TITLE
add support for importing createdAt

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -62,6 +62,7 @@ const userSchema = z.object({
 	private_metadata: z.record(z.string(), z.unknown()).optional(),
 	/** Metadata saved on the user, that can be updated from both the Frontend and Backend APIs. Note: Since this data can be modified from the frontend, it is not guaranteed to be safe. */
 	unsafe_metadata: z.record(z.string(), z.unknown()).optional(),
+    createdAt: z.string().optional(),
 });
 
 type User = z.infer<typeof userSchema>;
@@ -78,6 +79,7 @@ const createUser = (userData: User) =>
 				privateMetadata: userData.private_metadata,
 				publicMetadata: userData.public_metadata,
 				unsafeMetadata: userData.unsafe_metadata,
+                createdAt: userData.createdAt,
 		  })
 		: clerkClient.users.createUser({
 				externalId: userData.userId,
@@ -88,6 +90,7 @@ const createUser = (userData: User) =>
 				privateMetadata: userData.private_metadata,
 				publicMetadata: userData.public_metadata,
 				unsafeMetadata: userData.unsafe_metadata,
+                createdAt: userData.createdAt,
 		  });
 
 const now = new Date().toISOString().split(".")[0]; // YYYY-MM-DDTHH:mm:ss

--- a/samples/authjs.json
+++ b/samples/authjs.json
@@ -798,5 +798,14 @@
     "lastName": "One Hundred",
     "password": "$2a$12$9HhLqMJxqBKhlZasxjlhger67GFcC4aOAtpcU.THpcSLiQve4mq6.",
     "passwordHasher": "bcrypt"
+  },
+  {
+    "userId": "101",
+    "email": "user101@example.com",
+    "firstName": "User",
+    "lastName": "One Hundred and One",
+    "password": "$2a$12$9HhLqMJxqBKhlZasxjlhger67GFcC4aOAtpcU.THpcSLiQve4mq6.",
+    "passwordHasher": "bcrypt"
+    "createdAt": "2025-03-13T18:47:11.37331+00:00",
   }
 ]


### PR DESCRIPTION
It's helpful to see when the user actually signed up, versus just when the user was imported into Clerk. This change addresses this by allowing the `createdAt` value to be optionally provided in `users.json`. This parameter is [already supported](https://clerk.com/docs/references/backend/user/create-user) by the `createUser` function, so all I did was add the additional parameter to the zod schema and carry it over to the function call.

I've added a usage example in the sample file as well.