### PR TITLE
fix: Address code review issues and support username as identifier

### DIFF
--- a/src/delete/index.ts
+++ b/src/delete/index.ts
@@ -205,7 +205,6 @@ const deleteUser = async (
 			if (retryCount < MAX_RETRIES) {
 				// Calculate retry delay using shared utility function
 				const { delayMs, delaySeconds } = getRetryDelay(
-					retryCount,
 					retryAfterSeconds,
 					RETRY_DELAY_MS
 				);

--- a/src/migrate/cli.ts
+++ b/src/migrate/cli.ts
@@ -678,7 +678,7 @@ export async function runCLI() {
 	// Exit if no users have valid identifiers
 	if (analysis.identifiers.hasAnyIdentifier === 0) {
 		p.cancel(
-			'No users can be imported. All users are missing a valid identifier (verified email, verified phone, or username).'
+			'No users can be imported. All users are missing an identifier (verified email, verified phone, or username).'
 		);
 		process.exit(1);
 	}

--- a/src/migrate/functions.ts
+++ b/src/migrate/functions.ts
@@ -39,17 +39,17 @@ function transformUsers(
 	key: TransformerMapKeys,
 	dateTime: string
 ): { transformedData: User[]; validationFailed: number } {
-	// This applies to smaller numbers. Pass in 10, get 5 back.
 	const transformedData: User[] = [];
 	let validationFailed = 0;
+
+	// Look up transformer once, outside the loop
+	const transformer = transformers.find((obj) => obj.key === key);
+	if (transformer === undefined) {
+		throw new Error('No transformer found for the specified key');
+	}
+
 	for (let i = 0; i < users.length; i++) {
-		const transformerKeys = transformers.find((obj) => obj.key === key);
-
-		if (transformerKeys === undefined) {
-			throw new Error('No transformer found for the specified key');
-		}
-
-		const transformedUser = transformKeys(users[i], transformerKeys);
+		const transformedUser = transformKeys(users[i], transformer);
 
 		// Transform email to array for clerk transformer (merges primary + verified + unverified emails)
 		if (key === 'clerk') {
@@ -117,8 +117,8 @@ function transformUsers(
 		}
 
 		// Apply transformer-specific post-transformation if defined
-		if ('postTransform' in transformerKeys) {
-			transformerKeys.postTransform(transformedUser);
+		if ('postTransform' in transformer) {
+			transformer.postTransform(transformedUser);
 		}
 		const validationResult = userSchema.safeParse(transformedUser);
 		// Check if validation was successful

--- a/src/migrate/import-users.ts
+++ b/src/migrate/import-users.ts
@@ -262,7 +262,6 @@ async function processUserToClerk(
 			if (retryCount < MAX_RETRIES) {
 				// Calculate retry delay using shared utility function
 				const { delayMs, delaySeconds } = getRetryDelay(
-					retryCount,
 					retryAfterSeconds,
 					RETRY_DELAY_MS
 				);

--- a/src/migrate/transformers/supabase.ts
+++ b/src/migrate/transformers/supabase.ts
@@ -72,7 +72,7 @@ const supabaseTransformer = {
 				// Phone is verified - keep it as is
 				user.phone = phone;
 			} else {
-				// Email is unverified - move to unverifiedEmailAddresses
+				// Phone is unverified - move to unverifiedPhoneNumbers
 				user.unverifiedPhoneNumbers = phone;
 				delete user.phone;
 			}
@@ -81,7 +81,7 @@ const supabaseTransformer = {
 		// Clean up the emailConfirmedAt and phoneConfirmedAt fields as they aren't
 		// part of our schema
 		delete user.emailConfirmedAt;
-		delete user.phoneCofnirmedAt;
+		delete user.phoneConfirmedAt;
 	},
 	defaults: {
 		passwordHasher: 'bcrypt' as const,

--- a/src/migrate/validator.ts
+++ b/src/migrate/validator.ts
@@ -17,7 +17,7 @@ import { passwordHasherEnum } from '../types';
  * All fields are optional except:
  * - userId is required (for tracking and logging)
  * - passwordHasher is required when password is provided
- * - user must have at least one verified identifier (email or phone)
+ * - user must have at least one identifier (email, phone, or username)
  *
  * @remarks
  * Fields can accept single values or arrays (e.g., email: string | string[])
@@ -76,16 +76,17 @@ export const userSchema = z
 				if (Array.isArray(field)) return field.length > 0;
 				return false;
 			};
-			// Must have either verified email or verified phone
+			// Must have at least one identifier: email, phone, or username
 			const hasVerifiedEmail =
 				hasValue(data.email) || hasValue(data.emailAddresses);
 			const hasVerifiedPhone =
 				hasValue(data.phone) || hasValue(data.phoneNumbers);
-			return hasVerifiedEmail || hasVerifiedPhone;
+			const hasUsername = hasValue(data.username);
+			return hasVerifiedEmail || hasVerifiedPhone || hasUsername;
 		},
 		{
 			message:
-				'User must have either a verified email or verified phone number',
+				'User must have at least one identifier (email, phone, or username)',
 			path: ['email'],
 		}
 	);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -125,44 +125,26 @@ describe('getRetryDelay', () => {
 	const defaultDelayMs = 10000; // 10 seconds
 
 	test('returns default delay when no retryAfter provided', () => {
-		const result = getRetryDelay(0, undefined, defaultDelayMs);
+		const result = getRetryDelay(undefined, defaultDelayMs);
 		expect(result.delayMs).toBe(10000);
 		expect(result.delaySeconds).toBe(10);
 	});
 
 	test('uses retryAfter when provided', () => {
-		const result = getRetryDelay(0, 15, defaultDelayMs);
+		const result = getRetryDelay(15, defaultDelayMs);
 		expect(result.delayMs).toBe(15000);
 		expect(result.delaySeconds).toBe(15);
 	});
 
-	test('returns default delay for any retry count when no retryAfter', () => {
-		const result = getRetryDelay(1, undefined, defaultDelayMs);
-		expect(result.delayMs).toBe(10000);
-		expect(result.delaySeconds).toBe(10);
-	});
-
-	test('uses retryAfter for any retry count when provided', () => {
-		const result = getRetryDelay(1, 15, defaultDelayMs);
-		expect(result.delayMs).toBe(15000);
-		expect(result.delaySeconds).toBe(15);
-	});
-
-	test('returns default delay for subsequent retries when no retryAfter', () => {
-		const result = getRetryDelay(2, undefined, defaultDelayMs);
-		expect(result.delayMs).toBe(10000);
-		expect(result.delaySeconds).toBe(10);
-	});
-
-	test('uses retryAfter for subsequent retries when provided', () => {
-		const result = getRetryDelay(3, 20, defaultDelayMs);
+	test('uses retryAfter of 20 seconds', () => {
+		const result = getRetryDelay(20, defaultDelayMs);
 		expect(result.delayMs).toBe(20000);
 		expect(result.delaySeconds).toBe(20);
 	});
 
 	test('works with different default delays', () => {
 		const customDefault = 5000; // 5 seconds
-		const result = getRetryDelay(2, undefined, customDefault);
+		const result = getRetryDelay(undefined, customDefault);
 		expect(result.delayMs).toBe(5000);
 		expect(result.delaySeconds).toBe(5);
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,21 +169,19 @@ export function transformKeys<
  * Uses the Retry-After value from the API response if provided,
  * otherwise falls back to the default delay.
  *
- * @param retryCount - The current retry attempt (0-indexed, unused but kept for API compatibility)
  * @param retryAfterSeconds - Optional Retry-After value from response header
  * @param defaultDelayMs - Default delay in milliseconds (typically 10000ms)
  * @returns Object containing delayMs (milliseconds) and delaySeconds (for logging)
  *
  * @example
- * const { delayMs, delaySeconds } = getRetryDelay(0, undefined, 10000);
+ * const { delayMs, delaySeconds } = getRetryDelay(undefined, 10000);
  * // Returns: { delayMs: 10000, delaySeconds: 10 }
  *
  * @example
- * const { delayMs, delaySeconds } = getRetryDelay(1, 15, 10000);
+ * const { delayMs, delaySeconds } = getRetryDelay(15, 10000);
  * // Returns: { delayMs: 15000, delaySeconds: 15 }
  */
 export function getRetryDelay(
-	retryCount: number,
 	retryAfterSeconds: number | undefined,
 	defaultDelayMs: number
 ): { delayMs: number; delaySeconds: number } {


### PR DESCRIPTION
Follow up review/comments/fixes from #11.

## Summary
- Fixed typo in supabase transformer (phoneCofnirmedAt → phoneConfirmedAt)
- Removed unused retryCount parameter from getRetryDelay function
- Updated validator to accept username as a valid identifier alongside email/phone
- Moved transformer lookup outside the processing loop for better performance

## Test plan
- Run `bun run test` to verify all tests pass with the updated function signatures
- Tests for getRetryDelay have been updated to reflect the new signature
- Validator tests should confirm username-only users are now accepted

🤖 Generated with Claude Code