### PR TITLE
chore: Add @manovotny to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-*       @royanger
+* @manovotny @royanger


### PR DESCRIPTION
## Summary

- Added `@manovotny` as a code owner alongside `@royanger` so both are requested for review on all PRs
- Removed redundant comments from the file
- Cleaned up excessive whitespace indentation
- Alphabetized owner names

## Not Changed

- **Required approvals kept at default (1)**: With both owners listed on the same `*` pattern, only one approval is needed to satisfy the CODEOWNERS requirement. Requiring both would need a branch protection rule change, which is not necessary at this time.

## References

- [GitHub CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- Builds on #44 which originally added the CODEOWNERS file

🤖 Generated with [Claude Code](https://claude.com/claude-code)